### PR TITLE
feat(seo): make news and devlog findable and shareable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable
 
+# woff2_decompress fuer scripts/og.mjs: die OG-Karten werden mit den echten
+# Markenfonts gerendert, und die liegen nach dem Build nur als woff2 vor —
+# fontconfig, das librsvg in sharp benutzt, liest kein woff2.
+RUN apk add --no-cache woff2
+
 WORKDIR /app
 
 # Copy manifests first so the dependency layer is cached independently of source changes.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,6 +13,52 @@ const mediaSizes = fs.existsSync('./src/generated/media-sizes.json')
 	: {};
 
 /**
+ * Path -> ISO date, for the sitemap's `lastmod`.
+ *
+ * Read from the frontmatter with fs rather than from the content layer: the
+ * sitemap integration builds its list outside `astro:content`, and a config
+ * file cannot await a collection. The shapes are flat and known, so a regex is
+ * enough — the same reasoning as in scripts/og.mjs.
+ */
+const contentDates = (() => {
+	const dates = {};
+	const read = (dir, field) =>
+		fs.existsSync(dir)
+			? fs.readdirSync(dir).flatMap((file) => {
+					if (!file.endsWith('.md')) return [];
+					const raw = fs.readFileSync(`${dir}/${file}`, 'utf8');
+					const value = raw.match(new RegExp(`^${field}:\\s*"?([^"\\n]+)"?`, 'm'))?.[1];
+					const slug = raw.match(/^slug:\s*"?([^"\n]+)"?/m)?.[1];
+					return value ? [{ date: new Date(value), slug }] : [];
+				})
+			: [];
+
+	for (const { date, slug } of read('./src/content/news', 'pubDatetime')) {
+		if (slug) dates[`/news/${slug}`] = date.toISOString();
+	}
+
+	// The devlog has no per-entry page: a month URL is as fresh as its newest
+	// entry, and /devlog itself mirrors the newest month.
+	const devlog = read('./src/content/devlog', 'date');
+	for (const { date } of devlog) {
+		const key = `/devlog/${date.toISOString().slice(0, 7)}`;
+		if (!dates[key] || date.toISOString() > dates[key]) dates[key] = date.toISOString();
+	}
+	const newest = devlog.map((e) => e.date).sort((a, b) => b - a)[0];
+	if (newest) {
+		dates['/devlog'] = newest.toISOString();
+		dates['/news'] = Object.entries(dates)
+			.filter(([k]) => k.startsWith('/news/'))
+			.map(([, v]) => v)
+			.sort()
+			.at(-1);
+	}
+	// Die Startseite zeigt den neuesten Stand von beidem.
+	dates['/'] = Object.values(dates).sort().at(-1);
+	return dates;
+})();
+
+/**
  * Stamps every Markdown image with its real width/height plus lazy loading.
  * News and devlog entries carry their images inline in the body, so the
  * templates never see an `<img>` — this is the one place that can size them,
@@ -58,11 +104,18 @@ export default defineConfig({
 				"default-src 'self'",
 				"img-src 'self' data: https://media.voidtales.win",
 				"connect-src 'self' https://api.mcstatus.io", // ServerStatus.astro
-				"frame-src https://www.youtube-nocookie.com", // trailer embed
+				'frame-src https://www.youtube-nocookie.com', // trailer embed
 				"base-uri 'self'",
 				"form-action 'none'",
 				"object-src 'none'",
 			],
+			// Pagefind sucht in einem WebAssembly-Modul. Ohne 'wasm-unsafe-eval'
+			// blockt Chrome die Instanziierung und /search bleibt stumm. Das
+			// Schluesselwort erlaubt WASM und sonst nichts - insbesondere kein
+			// eval() und kein Inline-Script; die Hashes bleiben unangetastet.
+			scriptDirective: {
+				resources: ["'self'", "'wasm-unsafe-eval'"],
+			},
 			// Card animations carry their stagger index as style="--i: n".
 			// Attribute styles cannot be hashed and cannot execute anything, so
 			// this stays scoped to style-src-attr; script-src is untouched.
@@ -74,7 +127,21 @@ export default defineConfig({
 		},
 	},
 
-	integrations: [sitemap()],
+	integrations: [
+		sitemap({
+			// Raus aus der Sitemap:
+			//  /search  - eine Eingabemaske, kein Inhalt (traegt zusaetzlich noindex)
+			//  /devlog/ - Alias auf den neuesten Monat, canonical zeigt auf die
+			//             Monats-URL. Beide anzumelden waere Duplicate Content.
+			filter: (page) => !page.includes('/search/') && !page.endsWith('/devlog/'),
+			// Ohne lastmod sieht fuer einen Crawler jede der ~56 URLs gleich alt aus.
+			serialize(item) {
+				const path = new URL(item.url).pathname.replace(/\/$/, '') || '/';
+				const lastmod = contentDates[path];
+				return lastmod ? { ...item, lastmod } : item;
+			},
+		}),
+	],
 
 	markdown: {
 		processor: satteri({ hastPlugins: [satteriImageSizes] }),

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"start": "astro dev",
 		"media": "node scripts/media.mjs",
 		"prebuild": "pnpm run media",
-		"build": "astro check && astro build",
+		"build": "astro check && astro build && node scripts/og.mjs && pagefind --site dist",
 		"preview": "astro preview",
 		"astro": "astro",
 		"check": "astro check",
@@ -19,6 +19,7 @@
 	},
 	"dependencies": {
 		"@astrojs/check": "^0.9.10",
+		"@astrojs/rss": "^4.0.19",
 		"@astrojs/sitemap": "^3.7.3",
 		"@tailwindcss/vite": "^4.3.3",
 		"astro": "^7.1.4",
@@ -27,6 +28,7 @@
 	},
 	"devDependencies": {
 		"@astrojs/markdown-satteri": "^0.3.5",
+		"pagefind": "^1.5.2",
 		"prettier": "^3.8.1",
 		"prettier-plugin-astro": "^0.14.1",
 		"sharp": "^0.35.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.10
         version: 0.9.10(prettier-plugin-astro@0.14.1)(prettier@3.9.6)(typescript@5.9.3)
+      '@astrojs/rss':
+        specifier: ^4.0.19
+        version: 4.0.19
       '@astrojs/sitemap':
         specifier: ^3.7.3
         version: 3.7.3
@@ -30,6 +33,9 @@ importers:
       '@astrojs/markdown-satteri':
         specifier: ^0.3.5
         version: 0.3.5
+      pagefind:
+        specifier: ^1.5.2
+        version: 1.5.2
       prettier:
         specifier: ^3.8.1
         version: 3.9.6
@@ -139,6 +145,9 @@ packages:
   '@astrojs/prism@4.0.2':
     resolution: {integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==}
     engines: {node: '>=22.12.0'}
+
+  '@astrojs/rss@4.0.19':
+    resolution: {integrity: sha512-e+z5wYeYtffQdHQO8c2tkSd2JEBdAuRXJV4ZEU5IxkYeE6e39woDd7nw1PH1Kk2tEYNCYuKdylnnbhGmt61awA==}
 
   '@astrojs/sitemap@3.7.3':
     resolution: {integrity: sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==}
@@ -582,11 +591,49 @@ packages:
       '@emnapi/core': ^2.0.0-alpha.3
       '@emnapi/runtime': ^2.0.0-alpha.3
 
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
+
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@pagefind/darwin-arm64@1.5.2':
+    resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pagefind/darwin-x64@1.5.2':
+    resolution: {integrity: sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pagefind/freebsd-x64@1.5.2':
+    resolution: {integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@pagefind/linux-arm64@1.5.2':
+    resolution: {integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pagefind/linux-x64@1.5.2':
+    resolution: {integrity: sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pagefind/windows-arm64@1.5.2':
+    resolution: {integrity: sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pagefind/windows-x64@1.5.2':
+    resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
+    cpu: [x64]
+    os: [win32]
 
   '@rolldown/binding-android-arm64@1.1.5':
     resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
@@ -898,6 +945,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -1092,6 +1142,13 @@ packages:
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
+  fast-xml-builder@1.3.0:
+    resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
+
+  fast-xml-parser@5.10.1:
+    resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
+    hasBin: true
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1176,6 +1233,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-unsafe@2.0.0:
+    resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -1438,11 +1498,19 @@ packages:
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
+  pagefind@1.5.2:
+    resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
+    hasBin: true
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
+    engines: {node: '>=14.0.0'}
 
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
@@ -1590,6 +1658,9 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
+
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
 
   suf-log@2.5.3:
     resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
@@ -1905,6 +1976,10 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
+
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
@@ -2080,6 +2155,12 @@ snapshots:
   '@astrojs/prism@4.0.2':
     dependencies:
       prismjs: 1.30.0
+
+  '@astrojs/rss@4.0.19':
+    dependencies:
+      fast-xml-parser: 5.10.1
+      piccolore: 0.1.3
+      zod: 4.4.3
 
   '@astrojs/sitemap@3.7.3':
     dependencies:
@@ -2412,9 +2493,32 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@nodable/entities@3.0.0': {}
+
   '@oslojs/encoding@1.1.0': {}
 
   '@oxc-project/types@0.139.0': {}
+
+  '@pagefind/darwin-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/darwin-x64@1.5.2':
+    optional: true
+
+  '@pagefind/freebsd-x64@1.5.2':
+    optional: true
+
+  '@pagefind/linux-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/linux-x64@1.5.2':
+    optional: true
+
+  '@pagefind/windows-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/windows-x64@1.5.2':
+    optional: true
 
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
@@ -2694,6 +2798,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  anynum@1.0.1: {}
+
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
@@ -2965,6 +3071,20 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fast-xml-builder@1.3.0:
+    dependencies:
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
+
+  fast-xml-parser@5.10.1:
+    dependencies:
+      '@nodable/entities': 3.0.0
+      fast-xml-builder: 1.3.0
+      is-unsafe: 2.0.0
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.1
+      xml-naming: 0.3.0
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -3067,6 +3187,8 @@ snapshots:
   is-docker@4.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-unsafe@2.0.0: {}
 
   jiti@2.7.0: {}
 
@@ -3282,11 +3404,23 @@ snapshots:
 
   package-manager-detector@1.8.0: {}
 
+  pagefind@1.5.2:
+    optionalDependencies:
+      '@pagefind/darwin-arm64': 1.5.2
+      '@pagefind/darwin-x64': 1.5.2
+      '@pagefind/freebsd-x64': 1.5.2
+      '@pagefind/linux-arm64': 1.5.2
+      '@pagefind/linux-x64': 1.5.2
+      '@pagefind/windows-arm64': 1.5.2
+      '@pagefind/windows-x64': 1.5.2
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
 
   path-browserify@1.0.1: {}
+
+  path-expression-matcher@1.6.2: {}
 
   piccolore@0.1.3: {}
 
@@ -3474,6 +3608,10 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
 
   suf-log@2.5.3:
     dependencies:
@@ -3723,6 +3861,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  xml-naming@0.3.0: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/scripts/og.mjs
+++ b/scripts/og.mjs
@@ -1,0 +1,288 @@
+// Rendert alle OpenGraph-Karten (1200x630) aus einem SVG-Template: die
+// Standardkarte der Seite plus je eine pro News-Eintrag und pro Devlog-Monat.
+//
+// Laeuft NACH `astro build` und schreibt direkt nach dist/ - die Fonts kommen
+// aus dist/_astro/fonts/, und die HTML-Seiten verweisen ohnehin nur auf einen
+// vorhersagbaren Pfad (/images/og/...), der zum Zeitpunkt des Deploys da ist.
+//
+// Fonts: sharp rendert SVG-Text ueber librsvg/pango, und das sieht
+// ausschliesslich fontconfig-Fonts. Unbounded und Instrument Sans sind keine
+// Systemfonts, liegen aber nach dem Build als woff2 in dist/. Die werden hier
+// nach ttf entpackt (Binary woff2_decompress) und ueber eine temporaere
+// fonts.conf bekanntgemacht. sharp wird erst DANACH importiert - fontconfig
+// liest die Env beim ersten Text-Render, nicht spaeter.
+//
+// Doku: .claude/skills/brand-assets/SKILL.md
+import { execFileSync } from 'node:child_process';
+import {
+	globSync,
+	mkdtempSync,
+	mkdirSync,
+	copyFileSync,
+	writeFileSync,
+	readFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+const OUT_DIR = 'dist/images/og';
+
+// --- Fonts bereitstellen ---------------------------------------------------
+
+const woff2Files = globSync('dist/_astro/fonts/*.woff2');
+if (woff2Files.length === 0) {
+	console.error('Keine Fonts in dist/_astro/fonts/ - erst "astro build" laufen lassen.');
+	process.exit(1);
+}
+const fontDir = mkdtempSync(join(tmpdir(), 'og-fonts-'));
+for (const f of woff2Files) {
+	const target = join(fontDir, basename(f));
+	copyFileSync(f, target);
+	execFileSync('woff2_decompress', [target]); // schreibt .ttf daneben
+}
+writeFileSync(
+	join(fontDir, 'fonts.conf'),
+	`<?xml version="1.0"?>\n<!DOCTYPE fontconfig SYSTEM "fonts.dtd">\n<fontconfig>\n  <dir>${fontDir}</dir>\n  <cachedir>${fontDir}/cache</cachedir>\n</fontconfig>\n`
+);
+process.env.FONTCONFIG_FILE = join(fontDir, 'fonts.conf');
+
+const sharp = (await import('sharp')).default;
+
+// --- Design-Tokens ---------------------------------------------------------
+// Spiegeln das Dark-Theme aus src/styles/global.css. Bei Farbwechsel hier mit.
+
+const W = 1200;
+const H = 630;
+const bg = '#0a0714';
+const bgRaised = '#140f22';
+const text = '#ece8f6';
+const muted = '#9b93b3';
+const accent = '#a78bfa';
+
+const shot = await sharp('public/images/index-dark.webp')
+	.resize(W, H, { fit: 'cover' })
+	.png()
+	.toBuffer();
+const shotUri = `data:image/png;base64,${shot.toString('base64')}`;
+
+// --- Hilfsmittel -----------------------------------------------------------
+
+const escape = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+// Zeichenbreite geschaetzt statt gemessen: echte Metriken braeuchten einen
+// Font-Parser fuer einen Umbruch, der nur grob stimmen muss. Die Faktoren sind
+// an beiden Familien abgelesen; Unbounded ist deutlich breiter als die Sans.
+const wrap = (str, fontSize, factor, maxWidth, maxLines) => {
+	const perChar = fontSize * factor;
+	const limit = Math.max(8, Math.floor(maxWidth / perChar));
+	const lines = [];
+	let line = '';
+	for (const word of String(str).split(/\s+/)) {
+		const candidate = line ? `${line} ${word}` : word;
+		if (candidate.length <= limit) {
+			line = candidate;
+		} else {
+			if (line) lines.push(line);
+			line = word;
+			if (lines.length === maxLines) break;
+		}
+	}
+	if (line && lines.length < maxLines) lines.push(line);
+	if (lines.length === maxLines && lines.join(' ').length < String(str).length) {
+		lines[maxLines - 1] = `${lines[maxLines - 1].replace(/[\s.,;:!?-]+$/, '')}…`;
+	}
+	return lines;
+};
+
+const defs = `
+  <defs>
+    <linearGradient id="scrim" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="${bg}" stop-opacity="0.98"/>
+      <stop offset="52%" stop-color="${bg}" stop-opacity="0.88"/>
+      <stop offset="100%" stop-color="${bg}" stop-opacity="0.18"/>
+    </linearGradient>
+    <linearGradient id="floor" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="${bg}" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="${bg}" stop-opacity="0"/>
+    </linearGradient>
+    <radialGradient id="glowTL" cx="0" cy="0" r="1">
+      <stop offset="0%" stop-color="rgb(167 139 250 / 18%)"/>
+      <stop offset="100%" stop-color="rgb(167 139 250 / 0%)"/>
+    </radialGradient>
+    <filter id="titleGlow" x="-30%" y="-60%" width="160%" height="220%">
+      <feGaussianBlur stdDeviation="10" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="vGlow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="1.6" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <linearGradient id="vbg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="${bgRaised}"/>
+      <stop offset="100%" stop-color="${bg}"/>
+    </linearGradient>
+  </defs>`;
+
+const backdrop = `
+  <rect width="${W}" height="${H}" fill="${bg}"/>
+  <image href="${shotUri}" x="0" y="0" width="${W}" height="${H}"/>
+  <rect width="${W}" height="${H}" fill="url(#scrim)"/>
+  <rect x="0" y="${H - 200}" width="${W}" height="200" fill="url(#floor)"/>
+  <ellipse cx="120" cy="80" rx="700" ry="500" fill="url(#glowTL)"/>`;
+
+// Domain-Badge mit dem V-Mark des Favicons. y ist variabel, weil die
+// Eintragskarten unten mehr Text tragen als die Startseiten-Karte.
+const badge = (y) => `
+  <g transform="translate(84 ${y})">
+    <rect width="44" height="44" rx="10" fill="url(#vbg)" stroke="rgb(236 232 246 / 12%)"/>
+    <path d="M11 10.5 L22 31.5 L33 10.5" fill="none" stroke="${accent}" stroke-width="5"
+          stroke-linecap="round" stroke-linejoin="round" filter="url(#vGlow)"/>
+    <text x="62" y="29" font-family="Instrument Sans" font-weight="500" font-size="22"
+          fill="${text}">portal.voidtales.win</text>
+  </g>`;
+
+const render = async (svg, file) => {
+	await sharp(Buffer.from(svg), { density: 96 }).webp({ quality: 88 }).toFile(file);
+};
+
+// --- Startseiten-Karte -----------------------------------------------------
+// Ersetzt das frueher von Hand angestossene gen-og.mjs. Copy spiegelt
+// siteConfig.hero in src/config/site.js.
+
+const heroCard = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
+  ${defs}${backdrop}
+  <text x="84" y="176" font-family="monospace" font-size="19" letter-spacing="5" fill="${muted}">MINECRAFT MODPACK AND SERVER</text>
+  <text x="84" y="266" font-family="Unbounded" font-weight="800" font-size="62" fill="${text}">Void</text>
+  <text x="84" y="352" font-family="Unbounded" font-weight="800" font-size="62" fill="${accent}" filter="url(#titleGlow)">Tales</text>
+  <text x="84" y="414" font-family="Instrument Sans" font-size="24" fill="${muted}">Six shattered realms, the fragments of a fallen</text>
+  <text x="84" y="448" font-family="Instrument Sans" font-size="24" fill="${muted}">goddess, and the Soul Station between them.</text>
+  ${badge(500)}
+</svg>`;
+
+// --- Eintragskarte ---------------------------------------------------------
+
+const entryCard = ({ eyebrow, title, body }) => {
+	// Titelgroesse stuft sich nach Laenge, damit ein langer Discord-Titel nicht
+	// aus dem Bild laeuft und ein kurzer nicht verloren wirkt.
+	const size = title.length <= 34 ? 56 : title.length <= 70 ? 46 : 40;
+	const titleLines = wrap(title, size, 0.62, 1010, 3);
+	const bodyLines = body ? wrap(body, 23, 0.5, 1000, 2) : [];
+
+	const titleTop = 232;
+	const lineHeight = size * 1.22;
+	const titleSvg = titleLines
+		.map(
+			(l, i) =>
+				`<text x="84" y="${titleTop + i * lineHeight}" font-family="Unbounded" font-weight="800" font-size="${size}" fill="${i === 0 ? text : accent}"${i === 0 ? '' : ' filter="url(#titleGlow)"'}>${escape(l)}</text>`
+		)
+		.join('\n  ');
+
+	const bodyTop = titleTop + titleLines.length * lineHeight + 14;
+	const bodySvg = bodyLines
+		.map(
+			(l, i) =>
+				`<text x="84" y="${bodyTop + i * 32}" font-family="Instrument Sans" font-size="23" fill="${muted}">${escape(l)}</text>`
+		)
+		.join('\n  ');
+
+	return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
+  ${defs}${backdrop}
+  <text x="84" y="160" font-family="monospace" font-size="19" letter-spacing="5" fill="${muted}">${escape(eyebrow)}</text>
+  ${titleSvg}
+  ${bodySvg}
+  ${badge(H - 130)}
+</svg>`;
+};
+
+// --- Inhalte einlesen ------------------------------------------------------
+// Frontmatter wird hier von Hand geparst statt ueber astro:content: das Script
+// laeuft ausserhalb von Astro, und die Felder sind flach und bekannt.
+
+const frontmatter = (file) => {
+	const raw = readFileSync(file, 'utf8');
+	const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+	if (!match) return null;
+	const data = { _body: raw.slice(match[0].length) };
+	for (const line of match[1].split(/\r?\n/)) {
+		const kv = line.match(/^(\w+):\s*(.*)$/);
+		if (!kv) continue;
+		let value = kv[2].trim();
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1).replace(/\\n/g, ' ').replace(/\\"/g, '"');
+		}
+		data[kv[1]] = value;
+	}
+	return data;
+};
+
+// Der Auszug kommt aus dem Markdown-Body, nicht aus data.description: die wird
+// vom Discord-Import hart auf 100 Zeichen gekappt und endet mitten im Wort
+// ("...loyal compan..."). Auf einer Vorschaukarte ist das gut sichtbar.
+// Dieselbe Regel steckt in src/utils/excerpt.ts fuer die Meta-Description -
+// beide Seiten muessen denselben Text zeigen.
+const excerpt = (body, max = 150) => {
+	const plain = body
+		.replace(/!\[[^\]]*\]\([^)]*\)/g, '') // Bilder
+		.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // Links auf ihren Text
+		.replace(/[#*_>`~]/g, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+	if (plain.length <= max) return plain;
+	const cut = plain.slice(0, max);
+	return `${cut.slice(0, cut.lastIndexOf(' ')).replace(/[\s.,;:!?-]+$/, '')}…`;
+};
+
+const dateLabel = (iso) =>
+	new Intl.DateTimeFormat('en-GB', {
+		day: 'numeric',
+		month: 'long',
+		year: 'numeric',
+		timeZone: 'UTC',
+	})
+		.format(new Date(iso))
+		.toUpperCase();
+
+mkdirSync(OUT_DIR, { recursive: true });
+await render(heroCard, `${OUT_DIR}/default.webp`);
+let count = 1;
+
+for (const file of globSync('src/content/news/**/*.md')) {
+	const data = frontmatter(file);
+	if (!data?.slug || !data.title) continue;
+	await render(
+		entryCard({
+			eyebrow: `NEWS · ${dateLabel(data.pubDatetime)}`,
+			title: data.title,
+			body: excerpt(data._body),
+		}),
+		`${OUT_DIR}/news-${data.slug}.webp`
+	);
+	count++;
+}
+
+const months = new Set();
+for (const file of globSync('src/content/devlog/**/*.md')) {
+	const data = frontmatter(file);
+	if (data?.date) months.add(new Date(data.date).toISOString().slice(0, 7));
+}
+for (const month of months) {
+	const label = new Intl.DateTimeFormat('en-GB', {
+		month: 'long',
+		year: 'numeric',
+		timeZone: 'UTC',
+	}).format(new Date(`${month}-01T00:00:00Z`));
+	await render(
+		entryCard({
+			eyebrow: 'DEVLOG',
+			title: label,
+			body: 'Day-to-day progress on Void Tales, straight from the team.',
+		}),
+		`${OUT_DIR}/devlog-${month}.webp`
+	);
+	count++;
+}
+
+console.log(`${count} OG-Karten in ${OUT_DIR}`);

--- a/src/config/navigation.js
+++ b/src/config/navigation.js
@@ -5,13 +5,17 @@ export const navigationLinks = [
 	{ label: 'Gallery', href: 'https://gallery.voidtales.win' },
 	{ label: 'News', href: '/news' },
 	{ label: 'Devlog', href: '/devlog' },
+	{ label: 'Search', href: '/search' },
 	{ label: 'Discord', href: 'https://discord.voidtales.win' },
 	// The old mobile menu pointed at bluemap.voidtales.win, which is a 404.
 	{ label: 'World Map', href: 'https://dynmap.voidtales.win' },
 ];
 
 // Buttons in the "Follow the Journey" section at the bottom of the page.
-export const socialLinks = navigationLinks.filter((l) => l.label !== 'World Map');
+// Search is a tool, not a place to follow — same reasoning as World Map.
+export const socialLinks = navigationLinks.filter(
+	(l) => l.label !== 'World Map' && l.label !== 'Search'
+);
 
 // News and Devlog live on this site now, so the link list is no longer purely
 // external — only off-site links get a new tab.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,16 +9,67 @@ interface Props {
 	/** Page title, inserted into siteConfig.titleTemplate. Omit on the homepage. */
 	title?: string;
 	description?: string;
+	/**
+	 * Per-entry preview card, e.g. `/images/og/news-<slug>.webp`. Written by
+	 * scripts/og.mjs after the build, so the file exists in dist but never in
+	 * src — point at the path, do not import it.
+	 */
+	ogImage?: string;
+	/** Set on news entries: switches og:type to article and emits the date. */
+	published?: Date;
+	/** Page-specific JSON-LD. The WebSite node below is always emitted. */
+	schema?: Record<string, unknown>;
+	/** Keeps a page out of the index (search results, utility pages). */
+	noindex?: boolean;
+	/**
+	 * Overrides the canonical URL. Needed where the same content is reachable
+	 * under two paths — `/devlog` is an alias for the newest month.
+	 */
+	canonical?: string;
 }
 
-const { title, description = siteConfig.description } = Astro.props;
+const {
+	title,
+	description = siteConfig.description,
+	ogImage: pageOgImage,
+	published,
+	schema,
+	noindex = false,
+	canonical: canonicalOverride,
+} = Astro.props;
 
 const pageTitle = title ? siteConfig.titleTemplate.replace('%s', title) : siteConfig.name;
 
 // Relative og:image paths are ignored by Discord/X link previews — always absolute.
-const canonical = new URL(Astro.url.pathname, siteConfig.url).toString();
-const ogImage = new URL(siteConfig.ogImage, siteConfig.url).toString();
-const twitterImage = new URL(siteConfig.twitterImage, siteConfig.url).toString();
+const canonical = new URL(canonicalOverride ?? Astro.url.pathname, siteConfig.url).toString();
+const ogImage = new URL(pageOgImage ?? siteConfig.ogImage, siteConfig.url).toString();
+const twitterImage = new URL(pageOgImage ?? siteConfig.twitterImage, siteConfig.url).toString();
+
+// Two nodes on every page: who the site is, and what this page is. Google reads
+// the WebSite node for the brand and the sitelinks search box; the second node
+// comes from whichever template knows what it renders.
+const jsonLd = {
+	'@context': 'https://schema.org',
+	'@graph': [
+		{
+			'@type': 'WebSite',
+			'@id': `${siteConfig.url}/#website`,
+			url: `${siteConfig.url}/`,
+			name: siteConfig.name,
+			description: siteConfig.description,
+			inLanguage: 'en',
+			potentialAction: {
+				'@type': 'SearchAction',
+				target: {
+					'@type': 'EntryPoint',
+					urlTemplate: `${siteConfig.url}/search/?q={search_term_string}`,
+				},
+				'query-input': 'required name=search_term_string',
+			},
+		},
+		...(schema ? [schema] : []),
+	],
+};
 ---
 
 <!doctype html>
@@ -31,24 +82,33 @@ const twitterImage = new URL(siteConfig.twitterImage, siteConfig.url).toString()
 		<title>{pageTitle}</title>
 		<meta name="description" content={description} />
 		<meta name="theme-color" content={siteConfig.themeColor} />
+		{noindex && <meta name="robots" content="noindex, follow" />}
 		<link rel="canonical" href={canonical} />
 		{/* All four are generated from favicon.svg, see the brand-assets skill. */}
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="icon" sizes="32x32" href="/favicon.ico" />
 		<link rel="icon" type="image/png" sizes="192x192" href="/favicon-192x192.png" />
 		<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+		<link rel="alternate" type="application/rss+xml" title={siteConfig.name} href="/rss.xml" />
 
-		<meta property="og:type" content="website" />
+		<meta property="og:type" content={published ? 'article' : 'website'} />
 		<meta property="og:site_name" content={siteConfig.name} />
 		<meta property="og:title" content={pageTitle} />
 		<meta property="og:description" content={description} />
 		<meta property="og:url" content={canonical} />
 		<meta property="og:image" content={ogImage} />
+		{/* Discord and Slack size the preview from these before fetching it. */}
+		<meta property="og:image:width" content="1200" />
+		<meta property="og:image:height" content="630" />
+		<meta property="og:image:alt" content={pageTitle} />
+		{published && <meta property="article:published_time" content={published.toISOString()} />}
 		<meta name="twitter:card" content={siteConfig.twitterCard} />
 		<meta name="twitter:site" content={siteConfig.twitterSite} />
 		<meta name="twitter:title" content={pageTitle} />
 		<meta name="twitter:description" content={description} />
 		<meta name="twitter:image" content={twitterImage} />
+
+		<script type="application/ld+json" set:html={JSON.stringify(jsonLd)} is:inline />
 
 		{
 			/* Filter the preload by style, never by weight: in the build all weights

--- a/src/pages/devlog/[...month].astro
+++ b/src/pages/devlog/[...month].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { siteConfig } from '../../config/site.js';
 
 // One page per month rather than per N entries: a month URL still points at the
 // same entries a year from now, while /devlog/2 shifts by one every time
@@ -66,13 +67,44 @@ const dayFormat = new Intl.DateTimeFormat('en-GB', {
 const label = (m: string) => monthFormat.format(new Date(`${m}-01T00:00:00Z`));
 const href = (m: string) => (m === months[0] ? '/devlog' : `/devlog/${m}`);
 const current = label(month);
+
+// /devlog und /devlog/<neuester-monat> liefern denselben Inhalt. Fuer Google
+// ist das Duplicate Content, und in der Pagefind-Suche standen beide Seiten
+// mit identischem Textausschnitt untereinander. Die Monats-URL ist die
+// bleibende, also zeigt der Alias per canonical dorthin und wird nicht
+// mitindexiert. Der Alias bleibt trotzdem: er ist der Navigationslink.
+const isAlias = Astro.params.month === undefined;
+
+// The day blocks are the real items here, and each one already carries an
+// anchor — so the month page is a CollectionPage of dated postings, not one
+// article. Without this a crawler sees one long page and no dates at all.
+const schema = {
+	'@type': 'CollectionPage',
+	'@id': `${new URL(href(month), siteConfig.url).toString()}#collection`,
+	name: `Devlog — ${current}`,
+	isPartOf: { '@id': `${siteConfig.url}/#website` },
+	hasPart: rendered.map((group) => ({
+		'@type': 'BlogPosting',
+		headline: `Devlog — ${dayFormat.format(group.date)}`,
+		datePublished: group.date.toISOString(),
+		...(group.author ? { author: { '@type': 'Person', name: group.author } } : {}),
+		url: new URL(`${href(month)}#${group.day}`, siteConfig.url).toString(),
+	})),
+};
 ---
 
 <BaseLayout
 	title={`Devlog — ${current}`}
 	description={`What was built on Void Tales in ${current}, day by day.`}
+	ogImage={`/images/og/devlog-${month}.webp`}
+	schema={schema}
+	canonical={`/devlog/${month}`}
 >
-	<section class="section">
+	<section
+		class="section"
+		data-pagefind-ignore={isAlias ? 'all' : undefined}
+		data-pagefind-meta={isAlias ? undefined : `title:Devlog — ${current}`}
+	>
 		<div class="shell shell-narrow">
 			<p class="eyebrow">From the workbench</p>
 			<h1 class="page-title">Devlog</h1>

--- a/src/pages/news/[...slug].astro
+++ b/src/pages/news/[...slug].astro
@@ -1,6 +1,8 @@
 ---
 import { getCollection, render } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { siteConfig } from '../../config/site.js';
+import { excerpt } from '../../utils/excerpt';
 
 export async function getStaticPaths() {
 	const entries = await getCollection('news');
@@ -16,9 +18,37 @@ const dateFormat = new Intl.DateTimeFormat('en-GB', {
 	year: 'numeric',
 	timeZone: 'UTC',
 });
+
+// The imported description is cut at 100 characters mid-word, which is exactly
+// what a search snippet shows. Fall back to the body whenever it looks cut.
+const description =
+	entry.data.description && !entry.data.description.trim().endsWith('...')
+		? entry.data.description
+		: excerpt(entry.body ?? '');
+
+const ogImage = `/images/og/news-${entry.data.slug}.webp`;
+const url = new URL(`/news/${entry.data.slug}`, siteConfig.url).toString();
+
+const schema = {
+	'@type': 'NewsArticle',
+	'@id': `${url}#article`,
+	headline: entry.data.title,
+	description,
+	datePublished: entry.data.pubDatetime.toISOString(),
+	image: new URL(ogImage, siteConfig.url).toString(),
+	mainEntityOfPage: url,
+	isPartOf: { '@id': `${siteConfig.url}/#website` },
+	publisher: { '@type': 'Organization', name: siteConfig.name, url: `${siteConfig.url}/` },
+};
 ---
 
-<BaseLayout title={entry.data.title} description={entry.data.description}>
+<BaseLayout
+	title={entry.data.title}
+	description={description}
+	ogImage={ogImage}
+	published={entry.data.pubDatetime}
+	schema={schema}
+>
 	<section class="section">
 		<div class="shell shell-narrow">
 			<a class="back-link" href="/news">← All news</a>

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { siteConfig } from '../../config/site.js';
 
 const entries = (await getCollection('news')).sort(
 	(a, b) => b.data.pubDatetime.valueOf() - a.data.pubDatetime.valueOf()
@@ -23,11 +24,30 @@ const dateFormat = new Intl.DateTimeFormat('en-GB', {
 	year: 'numeric',
 	timeZone: 'UTC',
 });
+
+// The whole archive as an ordered list, so this reads as an archive and not as
+// a page that happens to contain links.
+const schema = {
+	'@type': 'CollectionPage',
+	'@id': `${siteConfig.url}/news#collection`,
+	name: 'News',
+	isPartOf: { '@id': `${siteConfig.url}/#website` },
+	mainEntity: {
+		'@type': 'ItemList',
+		itemListElement: entries.map((entry, i) => ({
+			'@type': 'ListItem',
+			position: i + 1,
+			url: new URL(`/news/${entry.data.slug}`, siteConfig.url).toString(),
+			name: entry.data.title,
+		})),
+	},
+};
 ---
 
 <BaseLayout
 	title="News"
 	description="Announcements from the world of Void Tales — updates, events and patch notes."
+	schema={schema}
 >
 	<section class="section">
 		<div class="shell shell-narrow">

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,0 +1,28 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import { siteConfig } from '../config/site.js';
+import { excerpt } from '../utils/excerpt';
+
+// Nur News, nicht der Devlog: der Devlog hat keine Eintrags-URLs, sondern
+// Tagesanker in Monatsseiten. Ein Feed aus Ankern liefert jedem Reader
+// dieselbe Seite mehrfach.
+export async function GET(context) {
+	const entries = (await getCollection('news')).sort(
+		(a, b) => b.data.pubDatetime.valueOf() - a.data.pubDatetime.valueOf()
+	);
+
+	return rss({
+		title: siteConfig.name,
+		description: 'Announcements from the world of Void Tales.',
+		site: context.site ?? siteConfig.url,
+		items: entries.map((entry) => ({
+			title: entry.data.title,
+			pubDate: entry.data.pubDatetime,
+			link: `/news/${entry.data.slug}/`,
+			description:
+				entry.data.description && !entry.data.description.trim().endsWith('...')
+					? entry.data.description
+					: excerpt(entry.body ?? ''),
+		})),
+	});
+}

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,0 +1,87 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+// Pagefind indexiert nach dem Build das fertige dist/ und legt seinen Index
+// unter /pagefind/ ab - im Dev-Server gibt es den also nicht, die Seite bleibt
+// dort leer. Das ist der Preis dafuer, dass die Suche ohne Backend auskommt
+// und trotzdem den gerenderten Text findet, nicht nur Frontmatter.
+//
+// data-pagefind-ignore: sonst indexiert Pagefind seine eigene Suchseite mit.
+---
+
+<BaseLayout
+	title="Search"
+	description="Search every announcement and devlog entry from Void Tales."
+	noindex
+>
+	<section class="section" data-pagefind-ignore>
+		<div class="shell shell-narrow">
+			<p class="eyebrow">Archive</p>
+			<h1 class="page-title">Search</h1>
+			<p class="section-lead">
+				Everything from <a href="/news">news</a> and the <a href="/devlog">devlog</a>, full text.
+			</p>
+
+			<div id="search"></div>
+
+			<noscript>
+				<p class="section-lead">
+					The search needs JavaScript. The full archive is browsable at <a href="/news">/news</a> and
+					<a href="/devlog">/devlog</a>.
+				</p>
+			</noscript>
+		</div>
+	</section>
+</BaseLayout>
+
+<link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
+
+<script>
+	// Kein Import: die Datei entsteht erst nach dem Build durch Pagefind, ein
+	// Bundler-Import wuerde den Build hier abbrechen lassen.
+	const load = () =>
+		new Promise((resolve, reject) => {
+			const el = document.createElement('script');
+			el.src = '/pagefind/pagefind-ui.js';
+			el.onload = resolve;
+			el.onerror = reject;
+			document.head.appendChild(el);
+		});
+
+	load()
+		.then(() => {
+			// @ts-expect-error - kommt aus dem oben nachgeladenen Script.
+			new PagefindUI({ element: '#search', showSubResults: true, showImages: false });
+
+			// Erlaubt /search/?q=... - genau das, was die SearchAction im JSON-LD
+			// der Startseite Google verspricht.
+			const q = new URLSearchParams(location.search).get('q');
+			if (q) {
+				const input = document.querySelector<HTMLInputElement>('#search input');
+				if (input) {
+					input.value = q;
+					input.dispatchEvent(new Event('input', { bubbles: true }));
+				}
+			}
+		})
+		.catch(() => {
+			const el = document.getElementById('search');
+			if (el) el.textContent = 'Search index unavailable.';
+		});
+</script>
+
+<style>
+	/* Pagefind bringt eigene Custom Properties mit; hier nur an das Theme
+	   angeglichen statt das Stylesheet zu ueberschreiben. */
+	#search {
+		--pagefind-ui-scale: 0.85;
+		--pagefind-ui-primary: var(--color-accent, #a78bfa);
+		--pagefind-ui-text: currentColor;
+		--pagefind-ui-background: transparent;
+		--pagefind-ui-border: color-mix(in oklab, currentColor 20%, transparent);
+		--pagefind-ui-border-width: 1px;
+		--pagefind-ui-border-radius: 0.75rem;
+		--pagefind-ui-font: inherit;
+		margin-top: 2rem;
+	}
+</style>

--- a/src/utils/excerpt.ts
+++ b/src/utils/excerpt.ts
@@ -1,0 +1,23 @@
+/**
+ * Erzeugt einen Meta-Description-Auszug aus einem Markdown-Body.
+ *
+ * Warum nicht `entry.data.description`: die schreibt der n8n-Import und kappt
+ * hart nach 100 Zeichen, mitten im Wort und mit angehaengten Punkten
+ * ("...loyal compan..."). Genau dieser Text landete bisher im
+ * <meta name="description"> und damit im Google-Snippet.
+ *
+ * Dieselbe Regel steckt in scripts/og.mjs fuer die Vorschaukarten - der Text
+ * auf der Karte und der im Snippet sollen derselbe sein.
+ */
+export function excerpt(body: string, max = 150): string {
+	const plain = body
+		.replace(/!\[[^\]]*\]\([^)]*\)/g, '') // Bilder raus
+		.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // Links auf ihren Text reduzieren
+		.replace(/[#*_>`~]/g, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+
+	if (plain.length <= max) return plain;
+	const cut = plain.slice(0, max);
+	return `${cut.slice(0, cut.lastIndexOf(' ')).replace(/[\s.,;:!?-]+$/, '')}…`;
+}


### PR DESCRIPTION
## Warum

Eine Google-Suche nach "Void Tales" führte auf vier Hosts, zwei davon tot. Auf dem Portal selbst fehlte alles, was einen Archiv-Inhalt auffindbar macht: jede der 56 Seiten teilte sich **ein** Vorschaubild, es gab keine strukturierten Daten, keine `lastmod` in der Sitemap, keine Suche, und die Meta-Descriptions kamen aus dem Discord-Import, der sie hart bei 100 Zeichen mitten im Wort abschneidet.

## Was drin ist

**Vorschaukarten pro Beitrag.** `scripts/og.mjs` rendert 55 Karten aus einem SVG-Template: die Seiten-Karte plus je eine pro News-Eintrag und Devlog-Monat, mit den echten Markenfonts über dem Hero-Screenshot. Es löst `gen-og.mjs` aus dem brand-assets-Skill ab, das Template liegt damit an einer Stelle statt an zweien, und es läuft als Teil des Builds.

**Descriptions aus dem Body.** `src/utils/excerpt.ts` greift, wenn die Frontmatter-Description abgeschnitten aussieht. Der Fix sitzt im Template statt in 41 Content-Dateien und gilt damit auch für jeden künftigen Import.

**Dazu:**

- JSON-LD auf jeder Seite: `WebSite` mit `SearchAction`, dazu `NewsArticle` bzw. `CollectionPage`
- `og:type: article` mit `article:published_time` auf News-Einträgen
- `lastmod` auf 56 von 58 Sitemap-URLs
- Volltextsuche mit Pagefind unter `/search`, erreicht auch die 235 Devlog-Einträge in den Monatsseiten
- RSS-Feed unter `/rss.xml`
- `/devlog` und `/devlog/<neuester-monat>` waren derselbe Inhalt unter zwei URLs; der Alias zeigt jetzt per canonical auf die Monats-URL

## Zwei Dinge, die beim Bauen aufgefallen sind

**`apk add woff2` musste ins Dockerfile.** sharp zeichnet SVG-Text über librsvg, das sieht nur fontconfig-Fonts, und die Astro-Fonts landen als woff2 in `dist/`. Unter `node:22-alpine` gegengetestet: die Karte ist identisch zur lokal gerenderten.

**Pagefind braucht `'wasm-unsafe-eval'` in `script-src`.** Es sucht in einem WebAssembly-Modul; ohne das Schlüsselwort blockt Chrome die Instanziierung und `/search` bleibt stumm. Das Schlüsselwort erlaubt WASM und sonst nichts, die Hashes bleiben unangetastet.

## Geprüft

- Build grün, `format:check` sauber, 55 Karten, 60 Seiten indexiert
- Im Browser: "Thalis" liefert 6 Treffer über News und Devlog, `?q=` greift, keine CSP-Violations
- `og:type`, `og:image` pro Eintrag, `article:published_time` und JSON-LD im gebauten HTML
